### PR TITLE
Fixes NREs

### DIFF
--- a/Source/Workshop/Workshop/OseModuleInventoryPreference.cs
+++ b/Source/Workshop/Workshop/OseModuleInventoryPreference.cs
@@ -40,6 +40,11 @@ namespace Workshop
 
         private bool VesselHasWorkshop()
         {
+            if (this.part.vessel == null)
+                return false;
+            if (this.part.vessel.Parts == null)
+                return false;
+
             foreach (var part in vessel.Parts)
             {
                 if (part.GetComponent<OseModuleWorkshop>() != null)


### PR DESCRIPTION
Fixes an NRE issue generated when the part module is instantiated but
the part has no vessel yet. This can happen when the part is selected in the VAB/SPH and is in the process of being dragged from the catalog and attached to the vessel. 
