### PR TITLE
Fix for KSP 1.1.2 and KIS 1.2.10

### DIFF
--- a/Source/Workshop/Workshop/KIS/KISWrapper.cs
+++ b/Source/Workshop/Workshop/KIS/KISWrapper.cs
@@ -14,9 +14,9 @@
 
         private static MethodInfo kis_GetPartVolume;
 
-        public static float GetPartVolume(Part partPrefab)
+        public static float GetPartVolume(AvailablePart part)
         {
-            return (float)kis_GetPartVolume.Invoke(null, new object[] { partPrefab });
+            return (float)kis_GetPartVolume.Invoke(null, new object[] { part });
         }
 
         internal static void Initialize(Assembly kisAssembly)

--- a/Source/Workshop/Workshop/OSEModuleWorkshop.cs
+++ b/Source/Workshop/Workshop/OSEModuleWorkshop.cs
@@ -226,7 +226,7 @@
 
         private bool IsValid(AvailablePart loadedPart)
         {
-            return WorkshopUtils.PartResearched(loadedPart) && WorkshopUtils.GetPackedPartVolume(loadedPart.partPrefab) <= _maxVolume;
+            return WorkshopUtils.PartResearched(loadedPart) && WorkshopUtils.GetPackedPartVolume(loadedPart) <= _maxVolume;
         }
 
         private void LoadMaxVolume()

--- a/Source/Workshop/Workshop/OseAddonEditorFilter.cs
+++ b/Source/Workshop/Workshop/OseAddonEditorFilter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using KSP.UI.Screens;
+using KSP.UI;
 
 namespace Workshop
 {
@@ -32,8 +34,10 @@ namespace Workshop
             PartCategorizer.AddCustomSubcategoryFilter(filter, SubCategoryTitle, icon, p => AvPartItems.Contains(p.name));
 
             var button = filter.button.activeButton;
-            button.SetFalse(button, RUIToggleButtonTyped.ClickType.FORCED);
-            button.SetTrue(button, RUIToggleButtonTyped.ClickType.FORCED);
+
+            //button.SetState(true, RUIToggleButtonTyped.ClickType.FORCED, null);
+            //button.SetFalse(button, RUIToggleButtonTyped.ClickType.FORCED);
+            //button.SetTrue(button, RUIToggleButtonTyped.ClickType.FORCED);
         }
     }
 }

--- a/Source/Workshop/Workshop/OseModuleRecycler.cs
+++ b/Source/Workshop/Workshop/OseModuleRecycler.cs
@@ -217,15 +217,16 @@
             {
                 Status = "Not enough Crew to operate";
             }
-            else if (_broker.AmountAvailable(part, UpkeepResource, TimeWarp.deltaTime, "Both") < TimeWarp.deltaTime)
+            else if (_broker.AmountAvailable(part, UpkeepResource, TimeWarp.deltaTime, "ALL_VESSEL") < TimeWarp.deltaTime)
             {
                 Status = "Not enough " + UpkeepResource;
             }
             else
             {
                 Status = "Recycling " + _processedItem.Part.title;
-                _broker.RequestResource(part, UpkeepResource, TimeWarp.deltaTime, TimeWarp.deltaTime, "Both");
-                resourceToProduce.Processed += _broker.StoreResource(part, resourceToProduce.Name, unitsToProduce, TimeWarp.deltaTime, "Both");
+                _broker.RequestResource(part, UpkeepResource, TimeWarp.deltaTime, TimeWarp.deltaTime, "ALL_VESSEL");
+                var storeResource = _broker.StoreResource(part, resourceToProduce.Name, unitsToProduce, TimeWarp.deltaTime, "ALL_VESSEL");
+                resourceToProduce.Processed += unitsToProduce;
                 _progress = (float)(_processedBlueprint.GetProgress() * 100);
             }
         }

--- a/Source/Workshop/Workshop/WorkshopUtils.cs
+++ b/Source/Workshop/Workshop/WorkshopUtils.cs
@@ -11,9 +11,9 @@ namespace Workshop
 
     public class WorkshopUtils
     {
-        public static float GetPackedPartVolume(Part part)
+        public static float GetPackedPartVolume(AvailablePart part)
         {
-            var moduleKisItem = KISWrapper.GetKisItem(part);
+            var moduleKisItem = KISWrapper.GetKisItem(part.partPrefab);
             return moduleKisItem != null ? moduleKisItem.volumeOverride : KIS_Shared.GetPartVolume(part);
         }
 
@@ -26,7 +26,7 @@ namespace Workshop
 
         public static bool HasFreeSpace(ModuleKISInventory inventory, WorkshopItem item)
         {
-            return inventory.GetContentVolume() + KIS_Shared.GetPartVolume(item.Part.partPrefab) <= inventory.maxVolume;
+            return inventory.GetContentVolume() + KIS_Shared.GetPartVolume(item.Part) <= inventory.maxVolume;
         }
 
         public static bool HasFreeSlot(ModuleKISInventory inventory)
@@ -54,7 +54,7 @@ namespace Workshop
         {
             var sb = new StringBuilder();
             sb.AppendLine("Mass: " + part.partPrefab.mass + " tons");
-            sb.AppendLine("Volume: " + KIS_Shared.GetPartVolume(part.partPrefab).ToString("0.0") + " litres");
+            sb.AppendLine("Volume: " + KIS_Shared.GetPartVolume(part).ToString("0.0") + " litres");
             sb.AppendLine("Costs: " + part.cost + "$");
 
             foreach (var resourceInfo in part.partPrefab.Resources.list)


### PR DESCRIPTION
Fixes the KIS combatiblity issue and recycler progress counting below zero.

I've disabled some button state toggling in OSEAddonFilter.cs as I could compile the code there and didn't find a quick workaround. Seems to have no effect on functionality...

@obivandamme My fixes seem to work for some people according to their forum posts. I would be glad if you could merge my fix and release an updated version
