### PR TITLE
Fix issue 34: Operation is not valid due to the current state of the object

### DIFF
--- a/Source/Workshop/Workshop/OSEModuleWorkshop.cs
+++ b/Source/Workshop/Workshop/OSEModuleWorkshop.cs
@@ -386,7 +386,12 @@
 
         private void ExecuteManufacturing()
         {
-            var resourceToConsume = _processedBlueprint.First(r => r.Processed < r.Units);
+            var resourceToConsume = _processedBlueprint.FirstOrDefault(r => r.Processed < r.Units);
+            if (resourceToConsume == null)
+            {
+                _progress = 100.0f;
+                return;
+            }
             var unitsToConsume = Math.Min(resourceToConsume.Units - resourceToConsume.Processed, TimeWarp.deltaTime * ProductivityFactor);
 
             if (part.protoModuleCrew.Count < MinimumCrew)


### PR DESCRIPTION
Just adds an extra check for when there's no work left to be done, but progress isn't 100% yet.
